### PR TITLE
Update minver MinimumMajorMinor

### DIFF
--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <MinVerMinimumMajorMinor>0.0</MinVerMinimumMajorMinor>
+    <MinVerMinimumMajorMinor>1.1</MinVerMinimumMajorMinor>
     <MinVerAutoIncrement>minor</MinVerAutoIncrement>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Because the [1.0.0-alpha.1](https://github.com/Particular/NServiceBus.ClaimCheck.DataBus/releases/tag/1.0.1-alpha.1) tag is on `master` instead of `release-1`, MinVer is generating 1.0.1 alphas and it should be generating 1.1 alphas.  This change will force 1.1 alphas until the next minor is tagged. 